### PR TITLE
Enhance workflows with permissions, release notes, and version updates

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -8,6 +8,9 @@
 
 name: Maven Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ 'dev-1.x' ]

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,13 +21,15 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ inputs.revision }}
     steps:
       - name: Validate version format
         run: |
           if ! echo "${{ inputs.revision }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-          echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
-          exit 1
+            echo "Error: version '${{ inputs.revision }}' does not match the required pattern major.minor.patch"
+            exit 1
           fi
 
       - name: Checkout Source
@@ -59,12 +61,12 @@ jobs:
           SIGN_KEY: ${{ secrets.OSS_SIGNING_KEY }}
           SIGN_KEY_PASS: ${{ secrets.OSS_SIGNING_PASSWORD }}
 
-
   release:
     runs-on: ubuntu-latest
     needs: build
     permissions:
       contents: write
+      models: read
     steps:
       - name: Checkout Source
         uses: actions/checkout@v5
@@ -82,14 +84,90 @@ jobs:
             git push origin ${{ inputs.revision }}
           fi
 
+      - name: Generate Release Notes with Copilot
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT_TAG="${{ inputs.revision }}"
+
+          # Find the previous tag (the one before the current tag)
+          PREV_TAG=$(git describe --tags --abbrev=0 --exclude="${CURRENT_TAG}" HEAD 2>/dev/null || echo "")
+
+          # Collect commits between the previous tag and HEAD
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log --oneline "${PREV_TAG}..HEAD" 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="$PREV_TAG"
+          else
+            COMMITS=$(git log --oneline -50 2>/dev/null || echo "No commits found")
+            SINCE_LABEL="the beginning"
+          fi
+
+          # Export for Python (avoids shell-escaping issues with multiline content)
+          export CURRENT_TAG_DATA="$CURRENT_TAG"
+          export PREV_TAG_DATA="$SINCE_LABEL"
+          export COMMITS_DATA="$COMMITS"
+
+          # Call GitHub Copilot via GitHub Models API and capture the summary
+          SUMMARY=$(python3 << 'PYEOF'
+          import json, os, urllib.request, sys
+
+          current_tag = os.environ['CURRENT_TAG_DATA']
+          prev_tag    = os.environ['PREV_TAG_DATA']
+          commits     = os.environ['COMMITS_DATA']
+          token       = os.environ['GH_TOKEN']
+
+          prompt = (
+              f"Generate concise release notes for version {current_tag}.\n\n"
+              f"Commits since {prev_tag}:\n{commits}\n\n"
+              "Format the output as markdown with sections for New Features, Bug Fixes, "
+              "and Other Changes (only include sections that have relevant commits). "
+              "Be concise and clear."
+          )
+
+          payload = json.dumps({
+              "model": "gpt-4o",
+              "messages": [{"role": "user", "content": prompt}]
+          }).encode()
+
+          req = urllib.request.Request(
+              "https://models.inference.ai.azure.com/chat/completions",
+              data=payload,
+              headers={
+                  "Content-Type": "application/json",
+                  "Authorization": f"Bearer {token}"
+              }
+          )
+
+          try:
+              with urllib.request.urlopen(req) as resp:
+                  data = json.loads(resp.read())
+                  print(data["choices"][0]["message"]["content"])
+          except Exception as e:
+              print(f"Failed to generate summary via Copilot: {e}", file=sys.stderr)
+              print(f"_Release notes generation failed. Raw commits since {prev_tag}:_\n\n```\n{commits}\n```")
+          PYEOF
+          )
+
+          # Append the summary (with version header) to release-notes.md
+          NOTES_FILE="release-notes.md"
+          if [ ! -f "$NOTES_FILE" ]; then
+            printf "# Release Notes\n\n" > "$NOTES_FILE"
+          fi
+          printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
+
+          # Write the current release notes to a temp file for the Create Release step
+          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+
+          echo "Release notes generated and appended to $NOTES_FILE"
+
       - name: Create Release
         run: |
           if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
             echo "Release v${{ inputs.revision }} already exists, skipping."
           else
-            gh release create v${{ inputs.revision }} \
+            gh release create ${{ inputs.revision }} \
               --title "v${{ inputs.revision }}" \
-              --generate-notes \
+              --notes-file /tmp/current-release-notes.md \
               --latest
           fi
         env:
@@ -110,7 +188,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pom.xml
+          git add pom.xml release-notes.md
           git diff --cached --quiet && echo "No changes to commit" || \
             git commit -m "chore: bump version to next patch after publishing ${{ inputs.revision }}" && git push
 

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://maven.aliyun.com/repository/public/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.0              |
-| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.0              |
+| **0.2.x**    | Compatible with Spring Cloud 2022.0.x - 2025.0.x | 0.2.5              |
+| **0.1.x**    | Compatible with Spring Cloud Hoxton - 2021.0.x   | 0.1.5              |
 
 Then add the specific modules you need.
 

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -19,10 +19,10 @@
     <description>Microsphere Alibaba Druid Parent</description>
 
     <properties>
-        <!-- BOM -->
-        <microsphere-spring-cloud.version>0.1.9</microsphere-spring-cloud.version>
+        <!-- BOM versions -->
+        <microsphere-spring-cloud.version>0.1.10</microsphere-spring-cloud.version>
         <!-- Libraries -->
-        <druid.version>1.2.27</druid.version>
+        <druid.version>1.2.28</druid.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.9</version>
+        <version>0.1.10</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request introduces several improvements to the build and release workflows, updates dependencies, and refreshes documentation to reflect the latest versions. The most significant changes are the automation of release note generation using GitHub Copilot, updates to Maven and dependency versions, and minor documentation updates.

**CI/CD Workflow Improvements:**

* Automated the generation of release notes during the Maven publish workflow using GitHub Copilot and the Models API, appending the notes to `release-notes.md` and including them in the GitHub release. [[1]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR87-R170) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL113-R191)
* Added explicit workflow permissions in `.github/workflows/maven-build.yml` and `.github/workflows/maven-publish.yml` to enhance security and enable required API access. [[1]](diffhunk://#diff-3666a4bb90aefcffb84f1e981faea3bf4a2b870836765640bc46a0d98b7773f2R11-R13) [[2]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aR24-R25) [[3]](diffhunk://#diff-a31c6ada558b9f058a611b68d3f9cb0b9a901072c89d38fddc03cf929ef01e8aL62-R69)

**Dependency and Build Updates:**

* Upgraded Maven Wrapper to use Maven 3.9.15 (previously 3.9.9).
* Updated the parent POM and BOM versions (`microsphere-spring-cloud.version` to 0.1.10 and `druid.version` to 1.2.28). [[1]](diffhunk://#diff-523da15ea59795ae2bf050be755f4230952af355e881435371ec36b74609ee25L22-R25) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10)

**Documentation Updates:**

* Updated the latest version numbers for the 0.2.x and 0.1.x branches in `README.md` to 0.2.5 and 0.1.5, respectively.