### PR TITLE
Fix Dependabot YAML and enhance release notes with version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@
 
 version: 2
 updates:
-- package-ecosystem: "maven" # See documentation for possible values
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -119,8 +119,9 @@ jobs:
           prompt = (
               f"Generate concise release notes for version {current_tag}.\n\n"
               f"Commits since {prev_tag}:\n{commits}\n\n"
-              "Format the output as markdown with sections for New Features, Bug Fixes, "
-              "and Other Changes (only include sections that have relevant commits). "
+              "Format the output as markdown with sections if present for New Features, Bug Fixes, "
+              "Documentations, Dependency Updates, Test Improvements, Build and Workflow Enhancements "
+              "and Other Changes(excludes Full Changelog).\n\n"
               "Be concise and clear."
           )
 
@@ -153,20 +154,25 @@ jobs:
           if [ ! -f "$NOTES_FILE" ]; then
             printf "# Release Notes\n\n" > "$NOTES_FILE"
           fi
+          
+          FULL_CHANGELOG="**Full Changelog**: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/compare/$PREV_TAG...$CURRENT_TAG"
+          
           printf "## v%s\n\n%s\n\n" "$CURRENT_TAG" "$SUMMARY" >> "$NOTES_FILE"
-
+          printf "%s" "$FULL_CHANGELOG" >> "$NOTES_FILE"
+          
           # Write the current release notes to a temp file for the Create Release step
-          printf "%s" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s\n\n" "$SUMMARY" > /tmp/current-release-notes.md
+          printf "%s" "$FULL_CHANGELOG" >> /tmp/current-release-notes.md
 
           echo "Release notes generated and appended to $NOTES_FILE"
 
       - name: Create Release
         run: |
-          if gh release view "v${{ inputs.revision }}" >/dev/null 2>&1; then
-            echo "Release v${{ inputs.revision }} already exists, skipping."
+          if gh release view "${{ inputs.revision }}" >/dev/null 2>&1; then
+            echo "Release ${{ inputs.revision }} already exists, skipping."
           else
             gh release create ${{ inputs.revision }} \
-              --title "v${{ inputs.revision }}" \
+              --title "${{ inputs.revision }}" \
               --notes-file /tmp/current-release-notes.md \
               --latest
           fi

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.10</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.11</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <druid.version>1.2.28</druid.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request updates the release notes generation process and bumps the `microsphere-spring-cloud` dependency version across the project. The most important changes are summarized below.

**Release notes and workflow improvements:**

* Enhanced the release notes prompt in `.github/workflows/maven-publish.yml` to include additional sections: Documentations, Dependency Updates, Test Improvements, Build and Workflow Enhancements, and clarified that "Other Changes" excludes the full changelog.
* Appended a "Full Changelog" link to the generated release notes and ensured it is included both in the main notes file and the temporary file used for creating GitHub releases.
* Minor adjustment to the release creation step to remove the `v` prefix from the release tag in the title and view command for consistency.

**Dependency updates:**

* Updated the parent project version in `pom.xml` from `0.1.10` to `0.1.11` to use the latest `microsphere-spring-cloud-parent`.
* Updated the `microsphere-spring-cloud.version` property in `microsphere-alibaba-druid-parent/pom.xml` from `0.1.10` to `0.1.11`.