### PR TITLE
Update microsphere Spring Cloud BOM and fix XML syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 > Microsphere Projects for [Alibaba Druid](https://github.com/alibaba/druid)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/microsphere-projects/microsphere-alibaba-druid)
-
 [![Maven Build](https://github.com/microsphere-projects/microsphere-alibaba-druid/actions/workflows/maven-build.yml/badge.svg)](https://github.com/microsphere-projects/microsphere-alibaba-druid/actions/workflows/maven-build.yml)
 [![Codecov](https://codecov.io/gh/microsphere-projects/microsphere-alibaba-druid/branch/dev-1.x/graph/badge.svg)](https://app.codecov.io/gh/microsphere-projects/microsphere-alibaba-druid)
 ![Maven](https://img.shields.io/maven-central/v/io.github.microsphere-projects/microsphere-alibaba-druid-dependencies.svg)

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.16`           |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.16`           |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.17`           |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.17`           |
 
 Then add the specific modules you need.
 

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.20</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.21</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <druid.version>1.2.28</druid.version>
     </properties>

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.16</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.19</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <druid.version>1.2.28</druid.version>
     </properties>

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.19</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.20</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <druid.version>1.2.28</druid.version>
     </properties>

--- a/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/autoconfigure/AlibabaDruidAutoConfiguration.java
+++ b/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/autoconfigure/AlibabaDruidAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
 import org.springframework.context.annotation.Bean;
 
+import static io.microsphere.alibaba.druid.spring.beans.factory.config.DruidDataSourceBeanPostProcessor.BEAN_NAME;
 import static org.springframework.boot.jdbc.DataSourceUnwrapper.unwrap;
 
 /**
@@ -64,7 +65,7 @@ public class AlibabaDruidAutoConfiguration {
      * @param alibabaDruidProperties the Alibaba Druid properties
      * @return the configured {@link DruidDataSourceBeanPostProcessor}
      */
-    @Bean
+    @Bean(name = BEAN_NAME)
     public BeanPostProcessor druidDataSourceBeanPostProcessor(AlibabaDruidProperties alibabaDruidProperties) {
         Filter filter = alibabaDruidProperties.getFilter();
         return new DruidDataSourceBeanPostProcessor(filter.getClasses());

--- a/microsphere-alibaba-druid-spring-cloud/src/main/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfiguration.java
+++ b/microsphere-alibaba-druid-spring-cloud/src/main/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfiguration.java
@@ -16,26 +16,8 @@
  */
 package io.microsphere.alibaba.druid.spring.cloud.autoconfigure;
 
-import com.alibaba.druid.filter.Filter;
-import com.alibaba.druid.pool.DruidDataSource;
 import io.microsphere.alibaba.druid.spring.boot.AlibabaDruidProperties;
 import io.microsphere.alibaba.druid.spring.boot.condition.ConditionalOnAlibabaDruidAvailable;
-import io.microsphere.spring.cloud.client.condition.ConditionalOnFeaturesAvailable;
-import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.cloud.client.actuator.HasFeatures;
-import org.springframework.cloud.client.actuator.NamedFeature;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-
-import java.util.List;
-import java.util.Set;
-
-import static io.microsphere.alibaba.druid.constants.PropertyConstants.ALIBABA_DRUID_PROPERTY_NAME_PREFIX;
-import static io.microsphere.collection.ListUtils.newArrayList;
-import static io.microsphere.collection.SetUtils.of;
-import static io.microsphere.constants.SymbolConstants.DOT_CHAR;
-import static io.microsphere.spring.beans.BeanUtils.isBeanPresent;
-import static java.util.Collections.emptyList;
 
 /**
  * The Spring Cloud Auto-Configuration for Alibaba Druid
@@ -54,49 +36,5 @@ import static java.util.Collections.emptyList;
  * @since 1.0.0
  */
 @ConditionalOnAlibabaDruidAvailable
-@Import(AlibabaDruidCloudAutoConfiguration.FeaturesConfiguration.class)
 public class AlibabaDruidCloudAutoConfiguration {
-
-    @ConditionalOnFeaturesAvailable
-    public static class FeaturesConfiguration {
-
-        /**
-         * The bean name of {@link HasFeatures}
-         *
-         * @see #alibabaDruidFeatures(ListableBeanFactory)
-         */
-        public final static String ALIBABA_DRUID_FEATURES_BEAN_NAME = "alibabaDruidFeatures";
-
-        // TODO : Add more features, e.g: WebStatFilter
-        private static Set<Class<?>> typeFeatures = of(
-                DruidDataSource.class,
-                Filter.class
-        );
-
-        /**
-         * Register a {@link HasFeatures} bean that exposes the Alibaba Druid features
-         * ({@link DruidDataSource} and {@link Filter}) present in the application context.
-         *
-         * <h3>Example Usage</h3>
-         * <pre>{@code
-         *   // Registered automatically by Spring Cloud when features are enabled
-         *   // Exposes "microsphere.alibaba.druid.DruidDataSource" and
-         *   // "microsphere.alibaba.druid.Filter" named features if the beans are present
-         * }</pre>
-         *
-         * @param beanFactory the {@link ListableBeanFactory} used to check for bean presence
-         * @return a {@link HasFeatures} containing the named Druid features
-         */
-        @Bean(name = ALIBABA_DRUID_FEATURES_BEAN_NAME)
-        public HasFeatures alibabaDruidFeatures(ListableBeanFactory beanFactory) {
-            List<NamedFeature> namedFeatures = newArrayList(typeFeatures.size());
-            for (Class<?> type : typeFeatures) {
-                if (isBeanPresent(beanFactory, type)) {
-                    String name = ALIBABA_DRUID_PROPERTY_NAME_PREFIX + DOT_CHAR + type.getSimpleName();
-                    namedFeatures.add(new NamedFeature(name, type));
-                }
-            }
-            return new HasFeatures(emptyList(), namedFeatures);
-        }
-    }
 }

--- a/microsphere-alibaba-druid-spring-cloud/src/main/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfiguration.java
+++ b/microsphere-alibaba-druid-spring-cloud/src/main/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfiguration.java
@@ -20,7 +20,7 @@ import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
 import io.microsphere.alibaba.druid.spring.boot.AlibabaDruidProperties;
 import io.microsphere.alibaba.druid.spring.boot.condition.ConditionalOnAlibabaDruidAvailable;
-import io.microsphere.spring.cloud.client.condition.ConditionalOnFeaturesEnabled;
+import io.microsphere.spring.cloud.client.condition.ConditionalOnFeaturesAvailable;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.actuator.NamedFeature;
@@ -57,7 +57,7 @@ import static java.util.Collections.emptyList;
 @Import(AlibabaDruidCloudAutoConfiguration.FeaturesConfiguration.class)
 public class AlibabaDruidCloudAutoConfiguration {
 
-    @ConditionalOnFeaturesEnabled
+    @ConditionalOnFeaturesAvailable
     public static class FeaturesConfiguration {
 
         /**

--- a/microsphere-alibaba-druid-spring-cloud/src/main/resources/META-INF/config/default/features.yaml
+++ b/microsphere-alibaba-druid-spring-cloud/src/main/resources/META-INF/config/default/features.yaml
@@ -1,0 +1,8 @@
+microsphere:
+  spring:
+    cloud:
+      features:
+        abstract:
+          microsphere-alibaba-druid-core:
+            - com.alibaba.druid.pool.DruidDataSource
+            - com.alibaba.druid.filter.Filter

--- a/microsphere-alibaba-druid-spring-cloud/src/test/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfigurationTest.java
+++ b/microsphere-alibaba-druid-spring-cloud/src/test/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfigurationTest.java
@@ -19,14 +19,13 @@ package io.microsphere.alibaba.druid.spring.cloud.autoconfigure;
 import com.alibaba.druid.filter.Filter;
 import com.alibaba.druid.pool.DruidDataSource;
 import io.microsphere.alibaba.druid.filter.LoggingStatementFilter;
-import io.microsphere.alibaba.druid.spring.cloud.autoconfigure.AlibabaDruidCloudAutoConfiguration.FeaturesConfiguration;
 import io.microsphere.alibaba.druid.test.spring.AbstractDruidSpringTest;
 import io.microsphere.alibaba.druid.test.spring.DruidDataSourceTestConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.actuator.FeaturesEndpoint;
 import org.springframework.cloud.client.actuator.HasFeatures;
 import org.springframework.cloud.client.actuator.NamedFeature;
 
@@ -36,6 +35,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 /**
  * {@link AlibabaDruidCloudAutoConfiguration} Test
@@ -48,9 +48,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         LoggingStatementFilter.class,
         DruidDataSourceTestConfiguration.class,
         AlibabaDruidCloudAutoConfigurationTest.class
-}, webEnvironment = SpringBootTest.WebEnvironment.NONE,
+}, webEnvironment = NONE,
         properties = {
                 "microsphere.alibaba.druid.enabled=true",
+                "management.endpoints.web.exposure.include=features",
                 "spring.cloud.features.enabled=true",
                 "microsphere.alibaba.druid.filter.classes=io.microsphere.alibaba.druid.filter.LoggingStatementFilter"
         })
@@ -61,23 +62,21 @@ public class AlibabaDruidCloudAutoConfigurationTest extends AbstractDruidSpringT
     private Map<String, HasFeatures> hasFeaturesMap;
 
     @Autowired
-    private FeaturesConfiguration featuresConfiguration;
+    private FeaturesEndpoint featuresEndpoint;
 
     @Test
     public void test() {
         assertTrue(this.hasFeaturesMap.size() > 0);
-        HasFeatures hadFeatures = this.hasFeaturesMap.get("alibabaDruidFeatures");
+        HasFeatures hadFeatures = this.hasFeaturesMap.get("microsphere-alibaba-druid-core.features");
         assertNotNull(hadFeatures);
 
         List<NamedFeature> namedFeatures = hadFeatures.getNamedFeatures();
         assertEquals(2, namedFeatures.size());
 
-        assertNamedFeature(namedFeatures, 0, "microsphere.alibaba.druid.DruidDataSource", DruidDataSource.class);
-        assertNamedFeature(namedFeatures, 1, "microsphere.alibaba.druid.Filter", Filter.class);
+        assertNamedFeature(namedFeatures, 0, "microsphere-alibaba-druid-core:DruidDataSource", DruidDataSource.class);
+        assertNamedFeature(namedFeatures, 1, "microsphere-alibaba-druid-core:LoggingStatementFilter", LoggingStatementFilter.class);
 
-        HasFeatures hasFeatures = this.featuresConfiguration.alibabaDruidFeatures(new DefaultListableBeanFactory());
-        assertTrue(hasFeatures.getAbstractFeatures().isEmpty());
-        assertTrue(hasFeatures.getNamedFeatures().isEmpty());
+        assertNotNull(featuresEndpoint.features());
     }
 
     private void assertNamedFeature(List<NamedFeature> namedFeatures, int index, String name, Class<?> type) {

--- a/microsphere-alibaba-druid-spring/src/main/java/io/microsphere/alibaba/druid/spring/context/annotation/AlibabaDruidRegistrar.java
+++ b/microsphere-alibaba-druid-spring/src/main/java/io/microsphere/alibaba/druid/spring/context/annotation/AlibabaDruidRegistrar.java
@@ -20,10 +20,12 @@ import com.alibaba.druid.filter.AutoLoad;
 import com.alibaba.druid.filter.Filter;
 import io.microsphere.alibaba.druid.spring.beans.factory.config.DruidDataSourceBeanPostProcessor;
 import io.microsphere.spring.beans.BeanSource;
+import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
 import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
+import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanNameGenerator;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
-import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 
 import java.util.Set;
@@ -32,10 +34,9 @@ import static io.microsphere.alibaba.druid.spring.beans.factory.config.DruidData
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerBeanDefinition;
 import static io.microsphere.spring.beans.factory.support.BeanRegistrar.registerSpringFactoriesBeans;
 import static io.microsphere.util.ServiceLoaderUtils.getServiceClasses;
-import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
 
 /**
- * {@link BeanCapableImportCandidate}
+ * {@link AnnotatedBeanCapableImportBeanDefinitionRegistrar} class for Alibaba Druid
  *
  * <h3>Example Usage</h3>
  * <pre>{@code
@@ -48,20 +49,19 @@ import static org.springframework.core.annotation.AnnotationAttributes.fromMap;
  *
  * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
  * @see EnableAlibabaDruid
- * @see BeanCapableImportCandidate
+ * @see AnnotatedBeanCapableImportBeanDefinitionRegistrar
  * @see ImportBeanDefinitionRegistrar
  * @see DruidDataSourceBeanPostProcessor
  * @since 1.0.0
  */
-class AlibabaDruidRegistrar extends BeanCapableImportCandidate implements ImportBeanDefinitionRegistrar {
-
-    private static final String ANNOTATION_CLASS_NAME = EnableAlibabaDruid.class.getName();
+class AlibabaDruidRegistrar extends AnnotatedBeanCapableImportBeanDefinitionRegistrar<EnableAlibabaDruid> {
 
     @Override
-    public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
-        AnnotationAttributes attributes = fromMap(metadata.getAnnotationAttributes(ANNOTATION_CLASS_NAME));
-        Class<? extends Filter>[] filterClasses = (Class<? extends Filter>[]) attributes.getClassArray("filterClasses");
-        BeanSource[] sources = (BeanSource[]) attributes.get("sources");
+    protected void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry,
+                                           BeanNameGenerator importBeanNameGenerator,
+                                           ResolvablePlaceholderAnnotationAttributes<EnableAlibabaDruid> annotationAttributes) {
+        Class<? extends Filter>[] filterClasses = (Class<? extends Filter>[]) annotationAttributes.getClassArray("filterClasses");
+        BeanSource[] sources = (BeanSource[]) annotationAttributes.get("sources");
         registerFilterBeans(registry, filterClasses, sources);
     }
 

--- a/microsphere-alibaba-druid-spring/src/main/java/io/microsphere/alibaba/druid/spring/context/annotation/AlibabaDruidRegistrar.java
+++ b/microsphere-alibaba-druid-spring/src/main/java/io/microsphere/alibaba/druid/spring/context/annotation/AlibabaDruidRegistrar.java
@@ -21,7 +21,6 @@ import com.alibaba.druid.filter.Filter;
 import io.microsphere.alibaba.druid.spring.beans.factory.config.DruidDataSourceBeanPostProcessor;
 import io.microsphere.spring.beans.BeanSource;
 import io.microsphere.spring.context.annotation.AnnotatedBeanCapableImportBeanDefinitionRegistrar;
-import io.microsphere.spring.context.annotation.BeanCapableImportCandidate;
 import io.microsphere.spring.core.annotation.ResolvablePlaceholderAnnotationAttributes;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanNameGenerator;

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.20</version>
+        <version>0.1.21</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
         <version>0.1.19</version>
-    </parent>`
+    </parent>
 
     <groupId>io.github.microsphere-projects</groupId>
     <artifactId>microsphere-alibaba-druid</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.19</version>
+        <version>0.1.20</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.16</version>
-    </parent>
+        <version>0.1.19</version>
+    </parent>`
 
     <groupId>io.github.microsphere-projects</groupId>
     <artifactId>microsphere-alibaba-druid</artifactId>


### PR DESCRIPTION
This pull request updates dependencies and makes a minor improvement to bean naming in the Alibaba Druid Spring Boot auto-configuration. The most important changes are listed below.

Dependency version updates:

* Bumped `microsphere-spring-cloud` version from `0.1.16` to `0.1.19` in both the root `pom.xml` and the module-specific `microsphere-alibaba-druid-parent/pom.xml` to keep dependencies up to date. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L10-R10) [[2]](diffhunk://#diff-523da15ea59795ae2bf050be755f4230952af355e881435371ec36b74609ee25L23-R23)

Spring Boot auto-configuration improvement:

* Updated the `@Bean` annotation for `druidDataSourceBeanPostProcessor` in `AlibabaDruidAutoConfiguration` to explicitly set its bean name using the constant `BEAN_NAME` for better clarity and bean management. [[1]](diffhunk://#diff-433fb0aaf74e49a96d9984bda69ff453471e6710c43df5d9fd5f5f35f7e7c933L67-R68) [[2]](diffhunk://#diff-433fb0aaf74e49a96d9984bda69ff453471e6710c43df5d9fd5f5f35f7e7c933R32)