### PR TITLE
Update Microsphere Spring Cloud version and improve Druid configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.17`           |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.17`           |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.18`           |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.18`           |
 
 Then add the specific modules you need.
 

--- a/microsphere-alibaba-druid-core/pom.xml
+++ b/microsphere-alibaba-druid-core/pom.xml
@@ -64,6 +64,20 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Microsphere Logging Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logging-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Logback -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Logback -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/microsphere-alibaba-druid-core/pom.xml
+++ b/microsphere-alibaba-druid-core/pom.xml
@@ -22,7 +22,14 @@
 
     <dependencies>
 
-        <!-- Microsphere -->
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Microsphere Java Core -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-java-core</artifactId>
@@ -54,19 +61,6 @@
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-alibaba-druid-test</artifactId>
             <version>${revision}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Microsphere Spring Test -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-spring-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-logback</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-alibaba-druid-core/src/main/java/io/microsphere/alibaba/druid/constants/PropertyConstants.java
+++ b/microsphere-alibaba-druid-core/src/main/java/io/microsphere/alibaba/druid/constants/PropertyConstants.java
@@ -42,7 +42,7 @@ public interface PropertyConstants {
     /**
      * The property name prefix of Alibaba Druid : "microsphere.alibaba.druid."
      */
-    String ALIBABA_DRUID_PROPERTY_NAME_PREFIX = MICROSPHERE_PROPERTY_NAME_PREFIX + "alibaba.druid" + DOT;
+    String ALIBABA_DRUID_PROPERTY_NAME_PREFIX = MICROSPHERE_PROPERTY_NAME_PREFIX + "alibaba.druid";
 
     /**
      * The default property value of Alibaba Druid enabled : "true"
@@ -57,5 +57,5 @@ public interface PropertyConstants {
             defaultValue = DEFAULT_ALIBABA_DRUID_ENABLED_PROPERTY_VALUE,
             source = APPLICATION_SOURCE
     )
-    String ALIBABA_DRUID_ENABLED_PROPERTY_NAME = ALIBABA_DRUID_PROPERTY_NAME_PREFIX + ENABLED_PROPERTY_NAME;
+    String ALIBABA_DRUID_ENABLED_PROPERTY_NAME = ALIBABA_DRUID_PROPERTY_NAME_PREFIX + DOT + ENABLED_PROPERTY_NAME;
 }

--- a/microsphere-alibaba-druid-core/src/main/java/io/microsphere/alibaba/druid/constants/PropertyConstants.java
+++ b/microsphere-alibaba-druid-core/src/main/java/io/microsphere/alibaba/druid/constants/PropertyConstants.java
@@ -16,7 +16,12 @@
  */
 package io.microsphere.alibaba.druid.constants;
 
+import io.microsphere.annotation.ConfigurationProperty;
+
+import static io.microsphere.annotation.ConfigurationProperty.APPLICATION_SOURCE;
+import static io.microsphere.constants.PropertyConstants.ENABLED_PROPERTY_NAME;
 import static io.microsphere.constants.PropertyConstants.MICROSPHERE_PROPERTY_NAME_PREFIX;
+import static io.microsphere.constants.SymbolConstants.DOT;
 
 /**
  * The constants of Alibaba Druid Properties
@@ -35,7 +40,22 @@ import static io.microsphere.constants.PropertyConstants.MICROSPHERE_PROPERTY_NA
 public interface PropertyConstants {
 
     /**
-     * The property name of Alibaba Druid
+     * The property name prefix of Alibaba Druid : "microsphere.alibaba.druid."
      */
-    String ALIBABA_DRUID_PROPERTY_NAME_PREFIX = MICROSPHERE_PROPERTY_NAME_PREFIX + "alibaba.druid";
+    String ALIBABA_DRUID_PROPERTY_NAME_PREFIX = MICROSPHERE_PROPERTY_NAME_PREFIX + "alibaba.druid" + DOT;
+
+    /**
+     * The default property value of Alibaba Druid enabled : "true"
+     */
+    String DEFAULT_ALIBABA_DRUID_ENABLED_PROPERTY_VALUE = "true";
+
+    /**
+     * The property name of Alibaba Druid enabled : "microsphere.alibaba.druid.enabled"
+     */
+    @ConfigurationProperty(
+            type = boolean.class,
+            defaultValue = DEFAULT_ALIBABA_DRUID_ENABLED_PROPERTY_VALUE,
+            source = APPLICATION_SOURCE
+    )
+    String ALIBABA_DRUID_ENABLED_PROPERTY_NAME = ALIBABA_DRUID_PROPERTY_NAME_PREFIX + ENABLED_PROPERTY_NAME;
 }

--- a/microsphere-alibaba-druid-core/src/main/java/io/microsphere/alibaba/druid/constants/PropertyConstants.java
+++ b/microsphere-alibaba-druid-core/src/main/java/io/microsphere/alibaba/druid/constants/PropertyConstants.java
@@ -40,7 +40,7 @@ import static io.microsphere.constants.SymbolConstants.DOT;
 public interface PropertyConstants {
 
     /**
-     * The property name prefix of Alibaba Druid : "microsphere.alibaba.druid."
+     * The property name prefix of Alibaba Druid : "microsphere.alibaba.druid"
      */
     String ALIBABA_DRUID_PROPERTY_NAME_PREFIX = MICROSPHERE_PROPERTY_NAME_PREFIX + "alibaba.druid";
 

--- a/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/constants/PropertyConstantsTest.java
+++ b/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/constants/PropertyConstantsTest.java
@@ -18,6 +18,7 @@ package io.microsphere.alibaba.druid.constants;
 
 import org.junit.jupiter.api.Test;
 
+import static io.microsphere.alibaba.druid.constants.PropertyConstants.ALIBABA_DRUID_ENABLED_PROPERTY_NAME;
 import static io.microsphere.alibaba.druid.constants.PropertyConstants.ALIBABA_DRUID_PROPERTY_NAME_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -32,6 +33,7 @@ public class PropertyConstantsTest {
 
     @Test
     public void testConstants() {
-        assertEquals("microsphere.alibaba.druid", ALIBABA_DRUID_PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.alibaba.druid.", ALIBABA_DRUID_PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.alibaba.druid.enabled", ALIBABA_DRUID_ENABLED_PROPERTY_NAME);
     }
 }

--- a/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/constants/PropertyConstantsTest.java
+++ b/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/constants/PropertyConstantsTest.java
@@ -33,7 +33,7 @@ public class PropertyConstantsTest {
 
     @Test
     public void testConstants() {
-        assertEquals("microsphere.alibaba.druid.", ALIBABA_DRUID_PROPERTY_NAME_PREFIX);
+        assertEquals("microsphere.alibaba.druid", ALIBABA_DRUID_PROPERTY_NAME_PREFIX);
         assertEquals("microsphere.alibaba.druid.enabled", ALIBABA_DRUID_ENABLED_PROPERTY_NAME);
     }
 }

--- a/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/filter/AbstractStatementFilterTest.java
+++ b/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/filter/AbstractStatementFilterTest.java
@@ -21,7 +21,7 @@ import com.alibaba.druid.proxy.jdbc.DataSourceProxy;
 import com.alibaba.druid.proxy.jdbc.StatementProxy;
 import com.alibaba.druid.sql.ast.SQLStatement;
 import com.alibaba.druid.sql.ast.statement.SQLSelectStatement;
-import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import io.microsphere.logging.test.jupiter.LoggingLevelsClass;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @see AbstractStatementFilter
  * @since 1.0.0
  */
-@SpringLoggingTest
+@LoggingLevelsClass(levels = {"TRACE", "INFO", "ERROR"})
 class AbstractStatementFilterTest {
 
     private AbstractStatementFilter filter;

--- a/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/filter/LoggingStatementFilterTest.java
+++ b/microsphere-alibaba-druid-core/src/test/java/io/microsphere/alibaba/druid/filter/LoggingStatementFilterTest.java
@@ -16,7 +16,7 @@
  */
 package io.microsphere.alibaba.druid.filter;
 
-import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
+import io.microsphere.logging.test.jupiter.LoggingLevelsClass;
 
 /**
  * {@link LoggingStatementFilter} Test
@@ -25,7 +25,7 @@ import io.microsphere.spring.test.junit.jupiter.SpringLoggingTest;
  * @see LoggingStatementFilter
  * @since 1.0.0
  */
-@SpringLoggingTest
+@LoggingLevelsClass(levels = {"TRACE", "INFO", "ERROR"})
 public class LoggingStatementFilterTest extends AbstractFilterTest<LoggingStatementFilter> {
 
     @Override

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.21</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.23</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <druid.version>1.2.28</druid.version>
     </properties>

--- a/microsphere-alibaba-druid-spring-boot/pom.xml
+++ b/microsphere-alibaba-druid-spring-boot/pom.xml
@@ -22,6 +22,13 @@
 
     <dependencies>
 
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Microsphere Alibaba Druid -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
@@ -33,6 +40,7 @@
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-boot-core</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Alibaba Druid -->
@@ -42,7 +50,7 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Spring Boot -->
+        <!-- Spring Boot Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
@@ -61,6 +69,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -68,17 +82,18 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Spring Testing -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
         <!-- Spring Boot Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Alibaba Druid Spring Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-alibaba-druid-spring-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 
@@ -93,14 +108,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Microsphere Alibaba Druid Spring Test -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-alibaba-druid-spring-test</artifactId>
-            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-alibaba-druid-spring-boot/pom.xml
+++ b/microsphere-alibaba-druid-spring-boot/pom.xml
@@ -97,6 +97,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Microsphere Logback -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- H2 -->
         <dependency>
             <groupId>com.h2database</groupId>

--- a/microsphere-alibaba-druid-spring-boot/pom.xml
+++ b/microsphere-alibaba-druid-spring-boot/pom.xml
@@ -89,6 +89,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Microsphere Spring Boot Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Microsphere Alibaba Druid Spring Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>

--- a/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidAvailable.java
+++ b/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidAvailable.java
@@ -52,8 +52,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Inherited
 @ConditionalOnAlibabaDruidEnabled
-@ConditionalOnClass(name = "com.alibaba.druid.pool.DruidDataSource")
+@ConditionalOnClass(name = "com.alibaba.druid.pool.DruidDataSource")            // Alibaba Druid API
 public @interface ConditionalOnAlibabaDruidAvailable {
 }

--- a/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidAvailable.java
+++ b/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidAvailable.java
@@ -22,10 +22,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Conditional;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * The composite {@link Conditional} for Alibaba Druid :
@@ -48,10 +49,12 @@ import java.lang.annotation.Target;
  * @see ConditionalOnClass
  * @since 1.0.0
  */
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Target(TYPE)
+@Retention(RUNTIME)
 @Documented
 @ConditionalOnAlibabaDruidEnabled
-@ConditionalOnClass(name = "com.alibaba.druid.pool.DruidDataSource")            // Alibaba Druid API
+@ConditionalOnClass(name = {
+        "com.alibaba.druid.pool.DruidDataSource"                   // Alibaba Druid API
+})
 public @interface ConditionalOnAlibabaDruidAvailable {
 }

--- a/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidAvailable.java
+++ b/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidAvailable.java
@@ -23,7 +23,6 @@ import org.springframework.context.annotation.Conditional;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;

--- a/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidEnabled.java
+++ b/microsphere-alibaba-druid-spring-boot/src/main/java/io/microsphere/alibaba/druid/spring/boot/condition/ConditionalOnAlibabaDruidEnabled.java
@@ -19,14 +19,12 @@ package io.microsphere.alibaba.druid.spring.boot.condition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import static io.microsphere.alibaba.druid.constants.PropertyConstants.ALIBABA_DRUID_PROPERTY_NAME_PREFIX;
-import static io.microsphere.constants.PropertyConstants.ENABLED_PROPERTY_NAME;
+import static io.microsphere.alibaba.druid.constants.PropertyConstants.ALIBABA_DRUID_ENABLED_PROPERTY_NAME;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * The {@link ConditionalOnProperty @ConditionalOnProperty} variant for Alibaba Druid :
@@ -46,10 +44,9 @@ import static io.microsphere.constants.PropertyConstants.ENABLED_PROPERTY_NAME;
  * @see ConditionalOnProperty
  * @since 1.0.0
  */
-@Target(ElementType.TYPE)
-@Retention(RetentionPolicy.RUNTIME)
+@Target(TYPE)
+@Retention(RUNTIME)
 @Documented
-@Inherited
-@ConditionalOnProperty(prefix = ALIBABA_DRUID_PROPERTY_NAME_PREFIX, name = ENABLED_PROPERTY_NAME, matchIfMissing = true)
+@ConditionalOnProperty(name = ALIBABA_DRUID_ENABLED_PROPERTY_NAME, matchIfMissing = true)
 public @interface ConditionalOnAlibabaDruidEnabled {
 }

--- a/microsphere-alibaba-druid-spring-boot/src/test/java/io/microsphere/alibaba/druid/spring/boot/autoconfigure/AlibabaDruidAutoConfigurationIntegrationTest.java
+++ b/microsphere-alibaba-druid-spring-boot/src/test/java/io/microsphere/alibaba/druid/spring/boot/autoconfigure/AlibabaDruidAutoConfigurationIntegrationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.microsphere.alibaba.druid.spring.boot.autoconfigure;
+
+import io.microsphere.alibaba.druid.filter.LoggingStatementFilter;
+import io.microsphere.alibaba.druid.spring.boot.AlibabaDruidProperties;
+import io.microsphere.alibaba.druid.spring.boot.metadata.DruidDataSourcePoolMetadata;
+import io.microsphere.alibaba.druid.test.spring.AbstractDruidSpringTest;
+import io.microsphere.alibaba.druid.test.spring.DruidDataSourceTestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadata;
+import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+
+import static io.microsphere.util.ArrayUtils.of;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+/**
+ * {@link AlibabaDruidAutoConfiguration} Integration Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
+ * @see AlibabaDruidAutoConfiguration
+ * @since 1.0.0
+ */
+@SpringBootTest(
+        classes = {
+                LoggingStatementFilter.class,
+                DruidDataSourceTestConfiguration.class,
+                AlibabaDruidAutoConfigurationIntegrationTest.class
+        },
+        webEnvironment = NONE,
+        properties = {
+                "microsphere.alibaba.druid.enabled=true",
+                "microsphere.alibaba.druid.filter.classes=io.microsphere.alibaba.druid.filter.LoggingStatementFilter"
+        })
+@EnableAutoConfiguration
+public class AlibabaDruidAutoConfigurationIntegrationTest extends AbstractDruidSpringTest {
+
+    @Autowired
+    private AlibabaDruidProperties alibabaDruidProperties;
+
+    @Autowired
+    private LoggingStatementFilter loggingStatementFilter;
+
+    @Autowired
+    private DataSourcePoolMetadataProvider dataSourcePoolMetadataProvider;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Test
+    public void test() throws Throwable {
+        super.test();
+        assertNotNull(alibabaDruidProperties);
+        assertNotNull(loggingStatementFilter);
+
+        AlibabaDruidProperties.Filter filter = alibabaDruidProperties.getFilter();
+        assertNotNull(filter);
+
+        Class<? extends com.alibaba.druid.filter.Filter>[] classes = filter.getClasses();
+        assertNotNull(classes);
+        assertArrayEquals(of(LoggingStatementFilter.class), classes);
+
+        DataSourcePoolMetadata dataSourcePoolMetadata = dataSourcePoolMetadataProvider.getDataSourcePoolMetadata(dataSource);
+        assertInstanceOf(DruidDataSourcePoolMetadata.class, dataSourcePoolMetadata);
+    }
+}

--- a/microsphere-alibaba-druid-spring-boot/src/test/java/io/microsphere/alibaba/druid/spring/boot/autoconfigure/AlibabaDruidAutoConfigurationTest.java
+++ b/microsphere-alibaba-druid-spring-boot/src/test/java/io/microsphere/alibaba/druid/spring/boot/autoconfigure/AlibabaDruidAutoConfigurationTest.java
@@ -14,75 +14,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.microsphere.alibaba.druid.spring.boot.autoconfigure;
 
-import io.microsphere.alibaba.druid.filter.LoggingStatementFilter;
-import io.microsphere.alibaba.druid.spring.boot.AlibabaDruidProperties;
-import io.microsphere.alibaba.druid.spring.boot.metadata.DruidDataSourcePoolMetadata;
-import io.microsphere.alibaba.druid.test.spring.AbstractDruidSpringTest;
-import io.microsphere.alibaba.druid.test.spring.DruidDataSourceTestConfiguration;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadata;
-import org.springframework.boot.jdbc.metadata.DataSourcePoolMetadataProvider;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import io.microsphere.alibaba.druid.spring.beans.factory.config.DruidDataSourceBeanPostProcessor;
+import io.microsphere.spring.boot.test.AutoConfigurationTest;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import javax.sql.DataSource;
+import java.util.Set;
 
-import static io.microsphere.util.ArrayUtils.of;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 /**
  * {@link AlibabaDruidAutoConfiguration} Test
  *
- * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see AlibabaDruidAutoConfiguration
  * @since 1.0.0
  */
 @SpringBootTest(
         classes = {
-                LoggingStatementFilter.class,
-                DruidDataSourceTestConfiguration.class,
                 AlibabaDruidAutoConfigurationTest.class
         },
-        webEnvironment = NONE,
-        properties = {
-                "microsphere.alibaba.druid.enabled=true",
-                "microsphere.alibaba.druid.filter.classes=io.microsphere.alibaba.druid.filter.LoggingStatementFilter"
-        })
-@EnableAutoConfiguration
-public class AlibabaDruidAutoConfigurationTest extends AbstractDruidSpringTest {
+        webEnvironment = NONE
+)
+class AlibabaDruidAutoConfigurationTest extends AutoConfigurationTest<AlibabaDruidAutoConfiguration> {
 
-    @Autowired
-    private AlibabaDruidProperties alibabaDruidProperties;
+    @Override
+    protected void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses) {
+        autoConfiguredClasses.add(DruidDataSourceBeanPostProcessor.class);
+    }
 
-    @Autowired
-    private LoggingStatementFilter loggingStatementFilter;
+    @Override
+    protected void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues) {
+        globalDisabledPropertyValues.add("microsphere.alibaba.druid.enabled=false");
+    }
 
-    @Autowired
-    private DataSourcePoolMetadataProvider dataSourcePoolMetadataProvider;
-
-    @Autowired
-    private DataSource dataSource;
-
-    @Test
-    public void test() throws Throwable {
-        super.test();
-        assertNotNull(alibabaDruidProperties);
-        assertNotNull(loggingStatementFilter);
-
-        AlibabaDruidProperties.Filter filter = alibabaDruidProperties.getFilter();
-        assertNotNull(filter);
-
-        Class<? extends com.alibaba.druid.filter.Filter>[] classes = filter.getClasses();
-        assertNotNull(classes);
-        assertArrayEquals(of(LoggingStatementFilter.class), classes);
-
-        DataSourcePoolMetadata dataSourcePoolMetadata = dataSourcePoolMetadataProvider.getDataSourcePoolMetadata(dataSource);
-        assertInstanceOf(DruidDataSourcePoolMetadata.class, dataSourcePoolMetadata);
+    @Override
+    protected void configureGlobalMissingClasses(Set<Class<?>> globalMissingClasses) {
+        globalMissingClasses.add(DruidDataSource.class);
     }
 }

--- a/microsphere-alibaba-druid-spring-cloud/pom.xml
+++ b/microsphere-alibaba-druid-spring-cloud/pom.xml
@@ -22,6 +22,13 @@
 
     <dependencies>
 
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Microsphere Alibaba Druid -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
@@ -33,6 +40,7 @@
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-cloud-commons</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Alibaba Druid -->
@@ -68,6 +76,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -82,10 +96,11 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Spring Boot Testing -->
+        <!-- Microsphere Alibaba Druid Spring Test -->
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-test</artifactId>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-alibaba-druid-spring-test</artifactId>
+            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 
@@ -100,14 +115,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Microsphere Alibaba Druid Spring Test -->
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-alibaba-druid-spring-test</artifactId>
-            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-alibaba-druid-spring-cloud/pom.xml
+++ b/microsphere-alibaba-druid-spring-cloud/pom.xml
@@ -89,10 +89,10 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Spring Testing -->
+        <!-- Spring Boot Testing -->
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -101,6 +101,13 @@
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-alibaba-druid-spring-test</artifactId>
             <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Microsphere Logback -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-alibaba-druid-spring-cloud/pom.xml
+++ b/microsphere-alibaba-druid-spring-cloud/pom.xml
@@ -96,6 +96,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Microsphere Spring Boot Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Microsphere Alibaba Druid Spring Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>

--- a/microsphere-alibaba-druid-spring-cloud/src/test/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfigurationIntegrationTest.java
+++ b/microsphere-alibaba-druid-spring-cloud/src/test/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfigurationIntegrationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.microsphere.alibaba.druid.spring.cloud.autoconfigure;
+
+import com.alibaba.druid.pool.DruidDataSource;
+import io.microsphere.alibaba.druid.filter.LoggingStatementFilter;
+import io.microsphere.alibaba.druid.test.spring.AbstractDruidSpringTest;
+import io.microsphere.alibaba.druid.test.spring.DruidDataSourceTestConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.actuator.FeaturesEndpoint;
+import org.springframework.cloud.client.actuator.HasFeatures;
+import org.springframework.cloud.client.actuator.NamedFeature;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+/**
+ * {@link AlibabaDruidCloudAutoConfiguration} Integration Test
+ *
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
+ * @see AlibabaDruidCloudAutoConfiguration
+ * @since 1.0.0
+ */
+@SpringBootTest(classes = {
+        LoggingStatementFilter.class,
+        DruidDataSourceTestConfiguration.class,
+        AlibabaDruidCloudAutoConfigurationIntegrationTest.class
+}, webEnvironment = NONE,
+        properties = {
+                "microsphere.alibaba.druid.enabled=true",
+                "management.endpoints.web.exposure.include=features",
+                "spring.cloud.features.enabled=true",
+                "microsphere.alibaba.druid.filter.classes=io.microsphere.alibaba.druid.filter.LoggingStatementFilter"
+        })
+@EnableAutoConfiguration
+public class AlibabaDruidCloudAutoConfigurationIntegrationTest extends AbstractDruidSpringTest {
+
+    @Autowired
+    private Map<String, HasFeatures> hasFeaturesMap;
+
+    @Autowired
+    private FeaturesEndpoint featuresEndpoint;
+
+    @Test
+    public void test() {
+        assertTrue(this.hasFeaturesMap.size() > 0);
+        HasFeatures hadFeatures = this.hasFeaturesMap.get("microsphere-alibaba-druid-core.features");
+        assertNotNull(hadFeatures);
+
+        List<NamedFeature> namedFeatures = hadFeatures.getNamedFeatures();
+        assertEquals(2, namedFeatures.size());
+
+        assertNamedFeature(namedFeatures, 0, "microsphere-alibaba-druid-core:DruidDataSource", DruidDataSource.class);
+        assertNamedFeature(namedFeatures, 1, "microsphere-alibaba-druid-core:LoggingStatementFilter", LoggingStatementFilter.class);
+
+        assertNotNull(featuresEndpoint.features());
+    }
+
+    private void assertNamedFeature(List<NamedFeature> namedFeatures, int index, String name, Class<?> type) {
+        NamedFeature namedFeature = namedFeatures.get(index);
+        assertEquals(name, namedFeature.getName());
+        assertEquals(type, namedFeature.getType());
+    }
+}

--- a/microsphere-alibaba-druid-spring-cloud/src/test/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfigurationTest.java
+++ b/microsphere-alibaba-druid-spring-cloud/src/test/java/io/microsphere/alibaba/druid/spring/cloud/autoconfigure/AlibabaDruidCloudAutoConfigurationTest.java
@@ -14,74 +14,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.microsphere.alibaba.druid.spring.cloud.autoconfigure;
 
-import com.alibaba.druid.filter.Filter;
+
 import com.alibaba.druid.pool.DruidDataSource;
-import io.microsphere.alibaba.druid.filter.LoggingStatementFilter;
-import io.microsphere.alibaba.druid.test.spring.AbstractDruidSpringTest;
-import io.microsphere.alibaba.druid.test.spring.DruidDataSourceTestConfiguration;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import io.microsphere.spring.boot.test.AutoConfigurationTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.client.actuator.FeaturesEndpoint;
-import org.springframework.cloud.client.actuator.HasFeatures;
-import org.springframework.cloud.client.actuator.NamedFeature;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
 /**
  * {@link AlibabaDruidCloudAutoConfiguration} Test
  *
- * @author <a href="mailto:mercyblitz@gmail.com">Mercy<a/>
+ * @author <a href="mailto:mercyblitz@gmail.com">Mercy</a>
  * @see AlibabaDruidCloudAutoConfiguration
  * @since 1.0.0
  */
-@SpringBootTest(classes = {
-        LoggingStatementFilter.class,
-        DruidDataSourceTestConfiguration.class,
-        AlibabaDruidCloudAutoConfigurationTest.class
-}, webEnvironment = NONE,
-        properties = {
-                "microsphere.alibaba.druid.enabled=true",
-                "management.endpoints.web.exposure.include=features",
-                "spring.cloud.features.enabled=true",
-                "microsphere.alibaba.druid.filter.classes=io.microsphere.alibaba.druid.filter.LoggingStatementFilter"
-        })
-@EnableAutoConfiguration
-public class AlibabaDruidCloudAutoConfigurationTest extends AbstractDruidSpringTest {
+@SpringBootTest(
+        classes = {
+                AlibabaDruidCloudAutoConfigurationTest.class
+        },
+        webEnvironment = NONE
+)
+class AlibabaDruidCloudAutoConfigurationTest extends AutoConfigurationTest<AlibabaDruidCloudAutoConfiguration> {
 
-    @Autowired
-    private Map<String, HasFeatures> hasFeaturesMap;
-
-    @Autowired
-    private FeaturesEndpoint featuresEndpoint;
-
-    @Test
-    public void test() {
-        assertTrue(this.hasFeaturesMap.size() > 0);
-        HasFeatures hadFeatures = this.hasFeaturesMap.get("microsphere-alibaba-druid-core.features");
-        assertNotNull(hadFeatures);
-
-        List<NamedFeature> namedFeatures = hadFeatures.getNamedFeatures();
-        assertEquals(2, namedFeatures.size());
-
-        assertNamedFeature(namedFeatures, 0, "microsphere-alibaba-druid-core:DruidDataSource", DruidDataSource.class);
-        assertNamedFeature(namedFeatures, 1, "microsphere-alibaba-druid-core:LoggingStatementFilter", LoggingStatementFilter.class);
-
-        assertNotNull(featuresEndpoint.features());
+    @Override
+    protected void configureAutoConfiguredClasses(Set<Class<?>> autoConfiguredClasses) {
     }
 
-    private void assertNamedFeature(List<NamedFeature> namedFeatures, int index, String name, Class<?> type) {
-        NamedFeature namedFeature = namedFeatures.get(index);
-        assertEquals(name, namedFeature.getName());
-        assertEquals(type, namedFeature.getType());
+    @Override
+    protected void configureGlobalDisabledPropertyValues(Set<String> globalDisabledPropertyValues) {
+        globalDisabledPropertyValues.add("microsphere.alibaba.druid.enabled=false");
+    }
+
+    @Override
+    protected void configureGlobalMissingClasses(Set<Class<?>> globalMissingClasses) {
+        globalMissingClasses.add(DruidDataSource.class);
     }
 }

--- a/microsphere-alibaba-druid-spring-test/pom.xml
+++ b/microsphere-alibaba-druid-spring-test/pom.xml
@@ -22,11 +22,39 @@
 
     <dependencies>
 
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Spring Testing -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Spring Framework -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Microsphere Alibaba Druid -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-alibaba-druid-test</artifactId>
             <version>${revision}</version>
+        </dependency>
+
+        <!-- Microsphere Spring Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-spring-test</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Microsphere Spring -->
@@ -47,27 +75,6 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Spring Framework -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Testing -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Spring Testing -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/microsphere-alibaba-druid-spring-test/pom.xml
+++ b/microsphere-alibaba-druid-spring-test/pom.xml
@@ -64,6 +64,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Microsphere Logback -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Alibaba Druid -->
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/microsphere-alibaba-druid-spring/pom.xml
+++ b/microsphere-alibaba-druid-spring/pom.xml
@@ -99,6 +99,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Microsphere Logback -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Logback -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/microsphere-alibaba-druid-spring/pom.xml
+++ b/microsphere-alibaba-druid-spring/pom.xml
@@ -22,6 +22,13 @@
 
     <dependencies>
 
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Microsphere Alibaba Druid -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
@@ -29,10 +36,11 @@
             <version>${revision}</version>
         </dependency>
 
-        <!-- Microsphere Spring -->
+        <!-- Microsphere Spring Context -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-context</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Alibaba Druid -->
@@ -88,12 +96,6 @@
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-spring-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.microsphere-projects</groupId>
-            <artifactId>microsphere-logback</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/microsphere-alibaba-druid-test/pom.xml
+++ b/microsphere-alibaba-druid-test/pom.xml
@@ -43,6 +43,20 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Microsphere Logging Test -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logging-test</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Microsphere Logback -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-logback</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Alibaba Druid -->
         <dependency>
             <groupId>com.alibaba</groupId>

--- a/microsphere-alibaba-druid-test/pom.xml
+++ b/microsphere-alibaba-druid-test/pom.xml
@@ -22,10 +22,25 @@
 
     <dependencies>
 
+        <!-- Microsphere Annotation Processor -->
+        <dependency>
+            <groupId>io.github.microsphere-projects</groupId>
+            <artifactId>microsphere-annotation-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Microsphere Java Test -->
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-java-test</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Alibaba Druid -->
@@ -39,13 +54,6 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <!-- Testing -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
             <optional>true</optional>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.21</version>
+        <version>0.1.23</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request introduces several enhancements and dependency updates across the `microsphere-alibaba-druid` modules, with a focus on configuration improvements, dependency management, and test modernization. The most significant changes include the introduction of a unified property constant for enabling Alibaba Druid, improvements to conditional annotations, modernization of test dependencies and annotations, and the addition of an integration test for Spring Boot auto-configuration.

**Configuration and Property Constants:**
- Introduced `ALIBABA_DRUID_ENABLED_PROPERTY_NAME` as a single source of truth for enabling Alibaba Druid, annotated with `@ConfigurationProperty` for better configuration metadata. Updated related code and tests to use this constant. [[1]](diffhunk://#diff-638c2b2ae1b0c94b6b07fd016cadda5dc86685c1eada6685a0300c81959dbf7cR19-R24) [[2]](diffhunk://#diff-638c2b2ae1b0c94b6b07fd016cadda5dc86685c1eada6685a0300c81959dbf7cL38-R60) [[3]](diffhunk://#diff-7b8b60162a2f35b8ac9e002d1d43b000eb9a78595ccf6a14e0b5821e2b9219a9R21) [[4]](diffhunk://#diff-7b8b60162a2f35b8ac9e002d1d43b000eb9a78595ccf6a14e0b5821e2b9219a9R37)

**Conditional Annotations:**
- Simplified and unified the conditional annotations in `ConditionalOnAlibabaDruidAvailable` and `ConditionalOnAlibabaDruidEnabled` to use the new property constant and standard meta-annotations, improving maintainability and correctness. [[1]](diffhunk://#diff-d124ff7ffbbd057e56ad3dedce20687bba4ed28577ffaf5ab08a3a66acca6cfdL25-R30) [[2]](diffhunk://#diff-d124ff7ffbbd057e56ad3dedce20687bba4ed28577ffaf5ab08a3a66acca6cfdL52-R58) [[3]](diffhunk://#diff-692af65053e925e7e909cfab0f782b3da1d493b97e1109761acc78e319025ef5L22-R27) [[4]](diffhunk://#diff-692af65053e925e7e909cfab0f782b3da1d493b97e1109761acc78e319025ef5L49-R50)

**Dependency and Test Modernization:**
- Updated dependencies in `pom.xml` files to include the annotation processor, logging test modules, and the latest versions of related Microsphere and Spring Boot libraries. Replaced `spring-test` with `spring-boot-starter-test` and added test dependencies for logback and Alibaba Druid Spring Test. [[1]](diffhunk://#diff-0a09a10a3eef5b585fc824bf28658be40dd3544fdbc44f51851c7da3879b3eb2L25-R32) [[2]](diffhunk://#diff-0a09a10a3eef5b585fc824bf28658be40dd3544fdbc44f51851c7da3879b3eb2L60-R74) [[3]](diffhunk://#diff-d2a37b8b498b5c4ef91fd03873fbbfd11abb768bda9f6ef9aa5ad73aef5d8389R25-R31) [[4]](diffhunk://#diff-d2a37b8b498b5c4ef91fd03873fbbfd11abb768bda9f6ef9aa5ad73aef5d8389R43) [[5]](diffhunk://#diff-d2a37b8b498b5c4ef91fd03873fbbfd11abb768bda9f6ef9aa5ad73aef5d8389L45-R53) [[6]](diffhunk://#diff-d2a37b8b498b5c4ef91fd03873fbbfd11abb768bda9f6ef9aa5ad73aef5d8389R72-R110) [[7]](diffhunk://#diff-d2a37b8b498b5c4ef91fd03873fbbfd11abb768bda9f6ef9aa5ad73aef5d8389L99-L106) [[8]](diffhunk://#diff-523da15ea59795ae2bf050be755f4230952af355e881435371ec36b74609ee25L23-R23) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R66)

**Test Annotation Updates:**
- Replaced deprecated or project-specific test annotations (`SpringLoggingTest`) with the new `LoggingLevelsClass` annotation in test classes for improved logging level control during tests. [[1]](diffhunk://#diff-b2ca9bef3c438b4ec00c4cef8721f556e1e0d03b52808a9ae280f38207250755L24-R24) [[2]](diffhunk://#diff-b2ca9bef3c438b4ec00c4cef8721f556e1e0d03b52808a9ae280f38207250755L44-R44) [[3]](diffhunk://#diff-cce6d0e5ebc4b2475bb00959b4ca0f4605d23921d5afa19a897942a734355e40L19-R19) [[4]](diffhunk://#diff-cce6d0e5ebc4b2475bb00959b4ca0f4605d23921d5afa19a897942a734355e40L28-R28)

**Integration Testing:**
- Added a new integration test, `AlibabaDruidAutoConfigurationIntegrationTest`, to verify that Alibaba Druid auto-configuration, property binding, filter registration, and metadata provider integration work as expected in a Spring Boot context.