### PR TITLE
Update BOM version and README branch compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ pom.xml:
 
 | **Branches** | **Purpose**                                      | **Latest Version** |
 |--------------|--------------------------------------------------|--------------------|
-| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.18`           |
-| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.18`           |
+| **main**     | Compatible with Spring Cloud 2022.0.x - 2025.0.x | `0.2.19`           |
+| **1.x**      | Compatible with Spring Cloud Hoxton - 2021.0.x   | `0.1.19`           |
 
 Then add the specific modules you need.
 

--- a/microsphere-alibaba-druid-core/pom.xml
+++ b/microsphere-alibaba-druid-core/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>io.github.microsphere-projects</groupId>
             <artifactId>microsphere-java-core</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Alibaba Druid -->

--- a/microsphere-alibaba-druid-parent/pom.xml
+++ b/microsphere-alibaba-druid-parent/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <!-- BOM versions -->
-        <microsphere-spring-cloud.version>0.1.23</microsphere-spring-cloud.version>
+        <microsphere-spring-cloud.version>0.1.24</microsphere-spring-cloud.version>
         <!-- Libraries -->
         <druid.version>1.2.28</druid.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.microsphere-projects</groupId>
         <artifactId>microsphere-spring-cloud-parent</artifactId>
-        <version>0.1.23</version>
+        <version>0.1.24</version>
     </parent>
 
     <groupId>io.github.microsphere-projects</groupId>


### PR DESCRIPTION
This pull request contains several small but important dependency and documentation updates across the project. The main changes are version bumps for key dependencies and the addition of an optional dependency flag, ensuring compatibility and improved dependency management.

Dependency version updates:

* Updated the parent dependency version in `pom.xml` from `0.1.23` to `0.1.24` to align with the latest release.
* Updated the `microsphere-spring-cloud.version` property in `microsphere-alibaba-druid-parent/pom.xml` from `0.1.23` to `0.1.24`.

Dependency management improvements:

* Marked the `microsphere-java-core` dependency as optional in `microsphere-alibaba-druid-core/pom.xml` to allow more flexible dependency inclusion.

Documentation updates:

* Updated the latest version numbers for both the `main` and `1.x` branches in the version table in `README.md`.